### PR TITLE
Define sourceDescription in response

### DIFF
--- a/response.go
+++ b/response.go
@@ -46,10 +46,20 @@ type QueryDescription struct {
 	Topology      string
 }
 
+type QueryInfo struct {
+	QueryString     string
+	Sinks           []string
+	SinkKafkaTopics []string
+	Id              string
+	StatusCount     map[string]int
+	QueryType       string
+	State           string
+}
+
 type SourceDescription struct {
 	Name         string
-	ReadQueries  []Query
-	WriteQueries []Query
+	ReadQueries  []QueryInfo
+	WriteQueries []QueryInfo
 	Fields       []Field
 	Type         string
 	Key          string

--- a/response.go
+++ b/response.go
@@ -46,6 +46,24 @@ type QueryDescription struct {
 	Topology      string
 }
 
+type SourceDescription struct {
+	Name         string
+	ReadQueries  []Query
+	WriteQueries []Query
+	Fields       []Field
+	Type         string
+	Key          string
+	Timestamp    string
+	Format       string
+	Topic        string
+	Extended     bool
+	// Extended only
+	Statistics  string
+	ErrorStats  string
+	Replication int
+	Partitions  int
+}
+
 type KsqlResponseSlice []KsqlResponse
 type StreamSlice []Stream
 type TableSlice []Table
@@ -54,12 +72,13 @@ type QuerySlice []Query
 type KsqlResponse struct {
 	StatementText         string
 	Warnings              []string
-	Type                  string            `json:"@type"`
-	CommandId             string            `json:"commandId,omitempty"`
-	CommandSequenceNumber int64             `json:"commandSequenceNumber,omitempty"` // -1 if the operation was unsuccessful
-	CommandStatus         CommandStatus     `json:"commandStatus,omitempty"`
-	Stream                *StreamSlice      `json:"streams,omitempty"`
-	Tables                *TableSlice       `json:"tables,omitempty"`
-	Queries               *QuerySlice       `json:"queries,omitempty"`
-	QueryDescription      *QueryDescription `json:"queryDescription,omitempty"`
+	Type                  string             `json:"@type"`
+	CommandId             string             `json:"commandId,omitempty"`
+	CommandSequenceNumber int64              `json:"commandSequenceNumber,omitempty"` // -1 if the operation was unsuccessful
+	CommandStatus         CommandStatus      `json:"commandStatus,omitempty"`
+	Stream                *StreamSlice       `json:"streams,omitempty"`
+	Tables                *TableSlice        `json:"tables,omitempty"`
+	Queries               *QuerySlice        `json:"queries,omitempty"`
+	QueryDescription      *QueryDescription  `json:"queryDescription,omitempty"`
+	SourceDescription     *SourceDescription `json:"sourceDescription,omitempty"`
 }


### PR DESCRIPTION
This PR defines a struct for `sourceDescription` JSON response to support `DESCRIBE` query execution response defined in https://docs.ksqldb.io/en/latest/developer-guide/ksqldb-rest-api/ksql-endpoint/